### PR TITLE
Fix failing test

### DIFF
--- a/log_relay_test.go
+++ b/log_relay_test.go
@@ -115,6 +115,10 @@ func Test_relayLogs(t *testing.T) {
 
 			exec.relayLogs(quitChan, "deadbeef123123123", map[string]string{}, result)
 			exec.config.ContainerLogsStdout = true
+			select {
+			case <-quitChan:
+			case <-time.After(5 * time.Millisecond):
+			}
 
 			So(channelClosedSuccess, ShouldBeTrue)
 			resultBytes, _ := ioutil.ReadFile(tmpfn)


### PR DESCRIPTION
This removes the timing issue from the test to make sure we wait long enough for slow hosts to aynchronously close the channel.