### PR TITLE
Fix shutdown from AWS Creds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.13.x
+  - 1.16.x
 
 before_install:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0

--- a/README.md
+++ b/README.md
@@ -261,7 +261,9 @@ vars so that they can be picked up by logging systems. They are as follows:
    request. By itself this will give you the default TTL for the policy
 
  * `vault.AWSRoleTTL` - This will allow you extend the requested time, up to
-   the max allowed by Vault for the policy
+   the max allowed by Vault for the policy. The value is a string, specified
+   in [Go Duration format](https://golang.org/pkg/time/#ParseDuration). E.g.
+   "1m40s" for 1 minute and 40 seconds.
 
 
 Configuring Docker Connectivity

--- a/executor.go
+++ b/executor.go
@@ -266,7 +266,7 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 	}
 
 	// watcherWg is used to let the Sidecar draining exit early if the
-	// container exits
+	// container exits, and when shutting down from the signal handler.
 	exec.watcherWg.Add(1)
 
 	containerName := container.GetContainerName(&taskInfo.TaskID)
@@ -466,7 +466,7 @@ func (exec *sidecarExecutor) monitorAWSCredsLease() {
 	}
 
 	log.Info("Attempting to shutdown because of AWS credential lease expiration")
-	ourProcess.Signal(syscall.SIGTERM)
+	ourProcess.Signal(syscall.SIGUSR1)
 }
 
 // AddAndMonitorVaultAWSKeys gets the aws keys for the specified role from Vault, begins monitoring

--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func handleSignals(scExec *sidecarExecutor) {
 	sigChan := make(chan os.Signal, 1) // Buffered!
 
 	// Grab some signals we want to catch where possible
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGUSR1)
 
 	sig := <-sigChan
 	log.Warnf("Received signal '%s', attempting clean shutdown", sig)


### PR DESCRIPTION
This was sometimes erroring, due to shutting down the container and then the Vault API call taking more than 3 seconds. Rather than add even more sleep, I introduced handling of `SIGUSR1` to indicate a self-shutdown. This now also properly waits on the `monitorTask()` goroutine to complete before proceeding, leveraging the `WaitGroup` already present.

Additional change here is that the TTL for Vault is parsed as a Go Duration instead of raw seconds. This was a trivial change and is a much better experience for the person configuring it.