### PR TITLE
Service-specific parent Vault tokens when AWS Role is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,21 @@ with `EXECUTOR_`.
    field. Defaults to the OS hostname and can be overridden with `LOG_HOSTNAME`
    in the environment.
 
+Special AWS Role Configuration
+------------------------------
+
+In addition to all the executor level settings above, you may also pass the
+following env vars into the executor to enable the executor to maintain AWS
+creds with a specific role via Vault:
+
+ * `EXECUTOR_VAULT_AWS_ROLE` - specifies the AWS role (pre-existing in IAM/Vault) to
+   request. By itself this will give you the default TTL for the policy
+
+ * `EXECUTOR_VAULT_AWS_ROLE_TTL` - This will allow you extend the requested time, up to
+   the max allowed by Vault for the policy. The value is a string, specified
+   in [Go Duration format](https://golang.org/pkg/time/#ParseDuration). E.g.
+   "1m40s" for 1 minute and 40 seconds.
+
 Vault Configuration
 -------------------
 
@@ -250,20 +265,6 @@ tokens in Vault, and that doesn't work well. Especially in a fast job failure
 scenario where executors running on multiple machines might be generating
 tokens constantly.
 
-### Docker Labels
-
-In configurations where it is desired for Vault to handle provisioning of AWS
-credentials using the AWS provider, you may pass two Docker labels into the
-deploy to configure this behavior. They are passed as labels instead of env
-vars so that they can be picked up by logging systems. They are as follows:
-
- * `vault.AWSRole` - specifies the AWS role (pre-existing in IAM/Vault) to
-   request. By itself this will give you the default TTL for the policy
-
- * `vault.AWSRoleTTL` - This will allow you extend the requested time, up to
-   the max allowed by Vault for the policy. The value is a string, specified
-   in [Go Duration format](https://golang.org/pkg/time/#ParseDuration). E.g.
-   "1m40s" for 1 minute and 40 seconds.
 
 
 Configuring Docker Connectivity

--- a/README.md
+++ b/README.md
@@ -234,10 +234,10 @@ In addition to all the executor level settings above, you may also pass the
 following env vars into the executor to enable the executor to maintain AWS
 creds with a specific role via Vault:
 
- * `EXECUTOR_VAULT_AWS_ROLE` - specifies the AWS role (pre-existing in IAM/Vault) to
+ * `EXECUTOR_AWS_ROLE` - specifies the AWS role (pre-existing in IAM/Vault) to
    request. By itself this will give you the default TTL for the policy
 
- * `EXECUTOR_VAULT_AWS_ROLE_TTL` - This will allow you extend the requested time, up to
+ * `EXECUTOR_AWS_ROLE_TTL` - This will allow you extend the requested time, up to
    the max allowed by Vault for the policy. The value is a string, specified
    in [Go Duration format](https://golang.org/pkg/time/#ParseDuration). E.g.
    "1m40s" for 1 minute and 40 seconds.

--- a/callbacks.go
+++ b/callbacks.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"os"
+	"time"
 
 	"github.com/Nitro/sidecar-executor/container"
 	mesos "github.com/mesos/mesos-go/api/v1/lib"
@@ -38,8 +38,8 @@ func (exec *sidecarExecutor) LaunchTask(taskInfo *mesos.TaskInfo) {
 	dockerLabels := container.LabelsForTask(taskInfo)
 
 	// Look up the AWS Role in Vault if we have one defined
-	if role := os.Getenv("EXECUTOR_VAULT_AWS_ROLE"); role != "" {
-		addEnvVars, err = exec.AddAndMonitorVaultAWSKeys(addEnvVars, role)
+	if exec.config.AWSRole != "" {
+		addEnvVars, err = exec.AddAndMonitorVaultAWSKeys(addEnvVars, exec.config.AWSRole)
 		if err != nil {
 			log.Error(err.Error())
 			exec.failTask(taskInfo)
@@ -47,8 +47,8 @@ func (exec *sidecarExecutor) LaunchTask(taskInfo *mesos.TaskInfo) {
 		}
 
 		// We can also have a custom TTL up to the Vault-configured max
-		if ttl := os.Getenv("EXECUTOR_VAULT_AWS_ROLE_TTL"); ttl != "" {
-			err = exec.SetVaultAWSTTL(ttl)
+		if exec.config.AWSRoleTTL != time.Duration(0) {
+			err = exec.SetVaultAWSTTL(exec.config.AWSRoleTTL)
 			if err != nil {
 				log.Error(err.Error())
 				exec.failTask(taskInfo)

--- a/callbacks.go
+++ b/callbacks.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/Nitro/sidecar-executor/container"
 	mesos "github.com/mesos/mesos-go/api/v1/lib"
 	"github.com/relistan/go-director"
@@ -36,7 +38,7 @@ func (exec *sidecarExecutor) LaunchTask(taskInfo *mesos.TaskInfo) {
 	dockerLabels := container.LabelsForTask(taskInfo)
 
 	// Look up the AWS Role in Vault if we have one defined
-	if role, ok := dockerLabels["vault.AWSRole"]; ok {
+	if role := os.Getenv("EXECUTOR_VAULT_AWS_ROLE"); role != "" {
 		addEnvVars, err = exec.AddAndMonitorVaultAWSKeys(addEnvVars, role)
 		if err != nil {
 			log.Error(err.Error())
@@ -45,7 +47,7 @@ func (exec *sidecarExecutor) LaunchTask(taskInfo *mesos.TaskInfo) {
 		}
 
 		// We can also have a custom TTL up to the Vault-configured max
-		if ttl, ok := dockerLabels["vault.AWSRoleTTL"]; ok {
+		if ttl := os.Getenv("EXECUTOR_VAULT_AWS_ROLE_TTL"); ttl != "" {
 			err = exec.SetVaultAWSTTL(ttl)
 			if err != nil {
 				log.Error(err.Error())

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -196,9 +196,6 @@ func Test_ExecutorCallbacks(t *testing.T) {
 		Reset(func() {
 			log.SetLevel(log.FatalLevel)
 			fakeServer.Close()
-
-			os.Unsetenv("EXECUTOR_VAULT_AWS_ROLE")
-			os.Unsetenv("EXECUTOR_VAULT_AWS_ROLE_TTL")
 		})
 
 		// Sidecar services handler

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -443,7 +443,7 @@ func Test_ExecutorCallbacks(t *testing.T) {
 			})
 
 			Convey("Gets AWS creds from Vault when a role is specified", func() {
-				os.Setenv("EXECUTOR_VAULT_AWS_ROLE", "valid-aws-role")
+				exec.config.AWSRole = "valid-aws-role"
 				taskInfo.Container.Docker.Parameters = labelsToDockerParams(dummyContainerLabels)
 
 				// We'll use logging output to validate that the goroutine ran
@@ -465,8 +465,8 @@ func Test_ExecutorCallbacks(t *testing.T) {
 			})
 
 			Convey("Ups the TTL on creds from Vault when specified", func() {
-				os.Setenv("EXECUTOR_VAULT_AWS_ROLE", "valid-aws-role")
-				os.Setenv("EXECUTOR_VAULT_AWS_ROLE_TTL", "1m40s")
+				exec.config.AWSRole = "valid-aws-role"
+				exec.config.AWSRoleTTL = time.Duration(1*time.Minute+40*time.Second)
 				taskInfo.Container.Docker.Parameters = labelsToDockerParams(dummyContainerLabels)
 
 				// We'll use logging output to validate that the goroutine ran
@@ -484,25 +484,8 @@ func Test_ExecutorCallbacks(t *testing.T) {
 				So(capture.String(), ShouldNotContainSubstring, "Unable to renew")
 			})
 
-			Convey("Fails the deploy when the TTL is not parseable", func() {
-				os.Setenv("EXECUTOR_VAULT_AWS_ROLE", "valid-aws-role")
-				os.Setenv("EXECUTOR_VAULT_AWS_ROLE_TTL", "100")
-				taskInfo.Container.Docker.Parameters = labelsToDockerParams(dummyContainerLabels)
-
-				// We'll use logging output to validate that the goroutine ran
-				var capture bytes.Buffer
-				log.SetLevel(log.DebugLevel)
-				log.SetOutput(&capture)
-
-				exec.LaunchTask(&taskInfo)
-
-				log.SetOutput(ioutil.Discard)
-
-				So(capture.String(), ShouldContainSubstring, "Invalid TTL passed in Docker label vaul.AWSRoleTTL")
-			})
-
 			Convey("Fails to launch a task when the AWS Rols is wrong", func() {
-				os.Setenv("EXECUTOR_VAULT_AWS_ROLE", "invalid-aws-role")
+				exec.config.AWSRole = "invalid-aws-role"
 				taskInfo.Container.Docker.Parameters = labelsToDockerParams(dummyContainerLabels)
 
 				var capture bytes.Buffer
@@ -684,7 +667,7 @@ func Test_ExecutorCallbacks(t *testing.T) {
 			})
 
 			Convey("Revokes AWS creds from Vault when have a lease", func() {
-				os.Setenv("EXECUTOR_VAULT_AWS_ROLE", "valid-aws-role")
+				exec.config.AWSRole = "valid-aws-role"
 				taskInfo.Container.Docker.Parameters = labelsToDockerParams(dummyContainerLabels)
 
 				// We'll use logging output to validate that the goroutine ran
@@ -719,7 +702,7 @@ func Test_ExecutorCallbacks(t *testing.T) {
 			})
 
 			Convey("Revoke a service-specific Vault token when AWS role is specified", func() {
-				os.Setenv("EXECUTOR_VAULT_AWS_ROLE", "valid-aws-role")
+				exec.config.AWSRole = "valid-aws-role"
 				taskInfo.Container.Docker.Parameters = labelsToDockerParams(dummyContainerLabels)
 
 				// We'll use logging output to validate that the goroutine ran
@@ -736,7 +719,7 @@ func Test_ExecutorCallbacks(t *testing.T) {
 			})
 
 			Convey("Logs and error when AWS role is specified and we can't revoke our token", func() {
-				os.Setenv("EXECUTOR_VAULT_AWS_ROLE", "valid-aws-role")
+				exec.config.AWSRole = "valid-aws-role"
 				taskInfo.Container.Docker.Parameters = labelsToDockerParams(dummyContainerLabels)
 
 				// We'll use logging output to validate that the goroutine ran

--- a/callbacks_test.go
+++ b/callbacks_test.go
@@ -108,6 +108,10 @@ func (v *mockVault) DecryptAllEnv(envs []string) ([]string, error) {
 	return decryptedEnv, nil
 }
 
+func (v *mockVault) MaybeRevokeToken() error {
+	return nil
+}
+
 func (v *mockVault) GetAWSCredsLease(role string) (*vault.VaultAWSCredsLease, error) {
 	if role == "valid-aws-role" {
 		return &vault.VaultAWSCredsLease{
@@ -137,7 +141,7 @@ func (v *mockVault) RenewAWSCredsLease(awsCredsLease *vault.VaultAWSCredsLease, 
 		return nil, errors.New("intentional test error from renew")
 	}
 	return &vault.VaultAWSCredsLease{
-		LeaseID: awsCredsLease.LeaseID,
+		LeaseID:         awsCredsLease.LeaseID,
 		LeaseExpiryTime: awsCredsLease.LeaseExpiryTime.Add(time.Duration(ttl) * time.Second),
 	}, nil
 }

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -2,15 +2,13 @@ package container
 
 import (
 	"bytes"
-	"io/ioutil"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	mesos "github.com/mesos/mesos-go/api/v1/lib"
-	log "github.com/sirupsen/logrus"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -20,7 +18,7 @@ const (
 )
 
 func init() {
-	log.SetOutput(ioutil.Discard)
+	//log.SetOutput(ioutil.Discard)
 }
 
 func Test_PullImage(t *testing.T) {
@@ -188,7 +186,7 @@ func Test_ConfigGeneration(t *testing.T) {
 		svcNameLabel := "ServiceName=" + svcName
 
 		envName := "dev"
-		envNameLabel := "EnvironmentName=" + envName
+		envNameLabel := "Environment=" + envName
 
 		host := mesos.ContainerInfo_DockerInfo_HOST
 
@@ -334,23 +332,23 @@ func Test_ConfigGeneration(t *testing.T) {
 
 		Convey("maps ports into the environment", func() {
 			// We index backward to find the vars we just set
-			So(opts.Config.Env[len(opts.Config.Env)-6], ShouldEqual, "MESOS_PORT_443=10270")
+			So(opts.Config.Env, ShouldContain, "MESOS_PORT_443=10270")
 		})
 
 		Convey("maps the hostname into the environment", func() {
-			So(opts.Config.Env[len(opts.Config.Env)-4], ShouldEqual, "MESOS_HOSTNAME="+hostname)
+			So(opts.Config.Env, ShouldContain, "MESOS_HOSTNAME="+hostname)
 		})
 
 		Convey("maps the ServiceName into the environment", func() {
-			So(opts.Config.Env[len(opts.Config.Env)-3], ShouldEqual, "SERVICE_NAME="+svcName)
+			So(opts.Config.Env, ShouldContain, "SERVICE_NAME="+svcName)
 		})
 
 		Convey("maps the EnvironmentName into the environment", func() {
-			So(opts.Config.Env[len(opts.Config.Env)-2], ShouldEqual, "ENVIRONMENT_NAME="+envName)
+			So(opts.Config.Env, ShouldContain, "ENVIRONMENT="+envName)
 		})
 
 		Convey("maps the version into the environment", func() {
-			So(opts.Config.Env[len(opts.Config.Env)-1], ShouldEqual, "SERVICE_VERSION=1.0.0")
+			So(opts.Config.Env, ShouldContain, "SERVICE_VERSION=1.0.0")
 		})
 
 		Convey("fills in the exposed ports", func() {

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -2,6 +2,8 @@ package container
 
 import (
 	"bytes"
+	"io/ioutil"
+	"log"
 	"runtime"
 	"strings"
 	"testing"
@@ -18,7 +20,7 @@ const (
 )
 
 func init() {
-	//log.SetOutput(ioutil.Discard)
+	log.SetOutput(ioutil.Discard)
 }
 
 func Test_PullImage(t *testing.T) {

--- a/executor.go
+++ b/executor.go
@@ -305,7 +305,10 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 
 	// Clean up an AWS lease we might have, and revoke our own token if needed.
 	exec.maybeCleanupAWSCredsLease()
-	exec.vault.MaybeRevokeToken()
+	err = exec.vault.MaybeRevokeToken()
+	if err != nil {
+		log.Error(err.Error())
+	}
 
 	exec.handleContainerExit(taskInfo, exitCode)
 

--- a/executor.go
+++ b/executor.go
@@ -493,12 +493,8 @@ func (exec *sidecarExecutor) AddAndMonitorVaultAWSKeys(addEnvVars []string, role
 
 // SetVaultAWSTTL attempts to set the ttl in Vault for the AWS creds we have a lease for. This
 // will allow longer TTLs than the default, limited to no more than the max allowed by Vault.
-func (exec *sidecarExecutor) SetVaultAWSTTL(ttlStr string) error {
+func (exec *sidecarExecutor) SetVaultAWSTTL(ttl time.Duration) error {
 	log.Infof("Renewing AWS Lease ID '%s'", exec.awsCredsLease.LeaseID)
-	ttl, err := time.ParseDuration(ttlStr)
-	if ttl < 1 || err != nil {
-		return fmt.Errorf("Invalid TTL passed in Docker label vaul.AWSRoleTTL. Could not parse: '%s'", ttlStr)
-	}
 
 	newLease, err := exec.vault.RenewAWSCredsLease(exec.awsCredsLease, int(ttl.Seconds()))
 	if err != nil {

--- a/executor.go
+++ b/executor.go
@@ -303,7 +303,9 @@ func (exec *sidecarExecutor) monitorTask(cntnrId string, taskInfo *mesos.TaskInf
 		}
 	}
 
+	// Clean up an AWS lease we might have, and revoke our own token if needed.
 	exec.maybeCleanupAWSCredsLease()
+	exec.vault.MaybeRevokeToken()
 
 	exec.handleContainerExit(taskInfo, exitCode)
 

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/Nitro/sidecar-executor/mesosdriver"
 	"github.com/Nitro/sidecar/service"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	mesosconfig "github.com/mesos/mesos-go/api/v1/lib/executor/config"
 	"github.com/relistan/envconfig"
 	log "github.com/sirupsen/logrus"
@@ -50,6 +50,10 @@ type Config struct {
 	ForceMemoryLimit        bool          `envconfig:"FORCE_MEMORY_LIMIT" default:"false"`
 	UseCpuShares            bool          `envconfig:"USE_CPU_SHARES" default:"false"`
 	Debug                   bool          `envconfig:"DEBUG" default:"false"`
+
+	// AWS Role options
+	AWSRole    string        `envconfig:"AWS_ROLE"`
+	AWSRoleTTL time.Duration `envconfig:"AWS_ROLE"`
 
 	// Mesos options
 	MesosMasterPort string `envconfig:"MESOS_MASTER_PORT" default:"5050"`
@@ -102,6 +106,8 @@ func logConfig(config Config) {
 	log.Infof(" * ContainerLogsStdout:     %t", config.ContainerLogsStdout)
 	log.Infof(" * SendDockerLabels:        %v", config.SendDockerLabels)
 	log.Infof(" * LogHostname:             %s", config.LogHostname)
+	log.Infof(" * AWSRole:                 %s", config.AWSRole)
+	log.Infof(" * AWSRoleTTL:              %s", config.AWSRoleTTL)
 	log.Infof(" * Debug:                   %t", config.Debug)
 
 	log.Infof("Environment ---------------------------")

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ type Config struct {
 
 	// AWS Role options
 	AWSRole    string        `envconfig:"AWS_ROLE"`
-	AWSRoleTTL time.Duration `envconfig:"AWS_ROLE"`
+	AWSRoleTTL time.Duration `envconfig:"AWS_ROLE_TTL"`
 
 	// Mesos options
 	MesosMasterPort string `envconfig:"MESOS_MASTER_PORT" default:"5050"`

--- a/main.go
+++ b/main.go
@@ -221,7 +221,7 @@ func handleSignals(scExec *sidecarExecutor) {
 	}
 
 	time.Sleep(3 * time.Second) // Try to let it quit
-	os.Exit(exitCode)                // Ctrl-C received or equivalent
+	os.Exit(exitCode)           // Ctrl-C received or equivalent
 }
 
 func initConfig() (Config, error) {

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -273,7 +273,7 @@ func (v EnvVault) MaybeRevokeToken() error {
 		return nil
 	}
 
-	log.Info("Revoking service-specific parent token in Vault")
+	log.Infof("Revoking service-specific parent token in Vault: %s", v.token)
 
 	r := v.client.NewRequest("POST", "/v1/auth/token/revoke-self")
 

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -80,7 +80,7 @@ func NewDefaultVault() EnvVault {
 	// Check if we are supposed to have our own token. If so, get one. Otherwise
 	// attempt to use the shared token from the file. If we're handling a role-specific
 	// set of creds, we need our own token's TTL to match those of the request.
-	if os.Getenv("EXECUTOR_VAULT_AWS_ROLE") != "" {
+	if os.Getenv("EXECUTOR_AWS_ROLE") != "" {
 		err := getAWSRoleVaultToken(&envVault)
 		if err != nil {
 			log.Errorf("Failed to get Vault parent Token to enable AWS Role: %s", err)
@@ -108,7 +108,7 @@ func getAWSRoleVaultToken(envVault *EnvVault) error {
 
 	log.Info("Attempting to get a parent token with TTL to match requested AWS Role")
 
-	if ttlStr := os.Getenv("EXECUTOR_VAULT_AWS_TTL"); ttlStr != "" {
+	if ttlStr := os.Getenv("EXECUTOR_AWS_TTL"); ttlStr != "" {
 		ttl, err = parseTokenTTL(ttlStr)
 		if err != nil {
 			return err

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -106,7 +106,7 @@ func getAWSRoleVaultToken(envVault *EnvVault) error {
 		err error
 	)
 
-	log.Info("Attempting to get a parent token with TTL to match requested AWS Role")
+	log.Info("Attempting to get a service-specific parent token with TTL to match requested AWS Role")
 
 	if ttlStr := os.Getenv("EXECUTOR_AWS_TTL"); ttlStr != "" {
 		ttl, err = parseTokenTTL(ttlStr)
@@ -125,6 +125,8 @@ func getAWSRoleVaultToken(envVault *EnvVault) error {
 	// Set the token on the client for use throughout its lifecycle
 	handler.SetToken(token)
 	envVault.token = token
+
+	log.Info("Service-specific token stored")
 
 	return nil
 }

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -152,7 +152,7 @@ func parseTokenTTL(ttlStr string) (int, error) {
 //
 //
 // By default, the key used to retrieve the contents of the Secret that Vault
-// returns is the string `VaultefaultKey`. If you have more than one entry stored in a
+// returns is the string `VaultDefaultKey`. If you have more than one entry stored in a
 // Secret and need to refer to them by name, you may append a query string
 // specifying the key, such as:
 //    vault://secret/prod-database?key=username

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -42,11 +42,15 @@ type Vault interface {
 	GetAWSCredsLease(role string) (*VaultAWSCredsLease, error)
 	RevokeAWSCredsLease(leaseID, role string) error
 	RenewAWSCredsLease(awsCredsLease *VaultAWSCredsLease, ttl int) (*VaultAWSCredsLease, error)
+	MaybeRevokeToken() error
 }
 
 // Client to replace vault paths by the secret value stored in Hashicorp Vault.
 type EnvVault struct {
 	client VaultAPI
+
+	// The token we are using, *if* it's specific to this executor and not shared
+	token string
 }
 
 // Our own narrowly-scoped interface for Hashicorp Vault Client
@@ -69,15 +73,57 @@ func NewDefaultVault() EnvVault {
 	log.Infof("Vault address '%s' ", conf.Address)
 
 	vaultClient, _ := api.NewClient(conf)
+	envVault := EnvVault{client: vaultClient}
 
-	if os.Getenv("VAULT_TOKEN") == "" {
+	// Check if we are supposed to have our own token. If so, get one. Otherwise
+	// attempt to use the shared token from the file. If we're handling a role-specific
+	// set of creds, we need our own token's TTL to match those of the request.
+	if os.Getenv("EXECUTOR_VAULT_AWS_ROLE") != "" {
+		err := getAWSRoleVaultToken(&envVault)
+		if err != nil {
+			log.Errorf("Failed to get Vault parent Token to enable AWS Role: %s", err)
+		}
+	} else if os.Getenv("VAULT_TOKEN") == "" {
+		// This will be a shared token
 		err := GetToken(&vaultTokenAuthHandler{client: vaultClient})
 		if err != nil {
 			log.Errorf("Failure authenticating with Vault: %s", err)
 		}
 	}
+	// otherwise the Vault client will use the one in the env var itself
 
-	return EnvVault{client: vaultClient}
+	return envVault
+}
+
+// getAWSRoleVaultToken is called when we need to have a TTL and token to match
+// those we'll be requesting for the service. Otherwise we can end up with the
+// service token expiring before we expect that to happen.
+func getAWSRoleVaultToken(envVault *EnvVault) error {
+	var ttl int
+
+	log.Info("Attempting to get a parent token with TTL to match requested AWS Role")
+
+	if ttlStr := os.Getenv("EXECUTOR_VAULT_AWS_TTL"); ttlStr != "" {
+		ttlTmp, err := time.ParseDuration(ttlStr)
+		if ttlTmp < 1 || err != nil {
+			return fmt.Errorf("Invalid TTL passed in Docker label vaul.AWSRoleTTL. Could not parse: '%s'", ttlStr)
+		}
+		// Seconds() returns a float64. We want the seconds, downgraded to an int
+		ttl = int(ttlTmp.Seconds())
+	}
+
+	handler := &vaultTokenAuthHandler{client: envVault.client.(*api.Client)}
+
+	token, err := GetTokenWithLogin(handler, ttl)
+	if err != nil {
+		return err
+	}
+
+	// Set the token on the client for use throughout its lifecycle
+	handler.SetToken(token)
+	envVault.token = token
+
+	return nil
 }
 
 // DecryptAllEnv decrypts all env vars that contain a Vault path.  All values
@@ -216,6 +262,41 @@ type VaultAWSCredsLease struct {
 	LeaseExpiryTime time.Time
 	LeaseID         string
 	Role            string
+}
+
+// MaybeRevokeToken will be called on shutdown, and *if* we cached a parent
+// token that was specific to this service, then we will expire it. If we
+// are using the shared token, we will not expire it.
+func (v EnvVault) MaybeRevokeToken() error {
+	// If we don't have one, this is a noop
+	if v.token == "" {
+		return nil
+	}
+
+	log.Info("Revoking service-specific parent token in Vault")
+
+	r := v.client.NewRequest("POST", "/v1/auth/token/revoke-self")
+
+	resp, err := v.client.RawRequest(r) // No body
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	// The Vault API is a little bit shit. We get a 204 back if the request was
+	// accepted, whether or not this is a valid lease. Adding the `sync` arg
+	// does not change this behavior. So... 204 is all we can look at.
+	if resp.StatusCode != 204 {
+		return fmt.Errorf(
+			"Failed to revoke service-specific parent token, got response code %d",
+			resp.StatusCode,
+		)
+	}
+
+	log.Info("Lease revoked")
+
+	return nil
 }
 
 // GetAWSCredsLease calls the Vault API and asks for AWS creds for a particular role,

--- a/vault/vault_auth_test.go
+++ b/vault/vault_auth_test.go
@@ -77,8 +77,8 @@ func Test_GetToken(t *testing.T) {
 				So(mock.ValidateWasCalled, ShouldBeFalse)
 				So(mock.token, ShouldEqual, "from_login")
 				So(mock.loginOptions["password"], ShouldEqual, "guinevere")
-				So(mock.loginOptions["ttl"], ShouldEqual, ttl)
-				So(mock.loginOptions["max_ttl"], ShouldEqual, ttl)
+				So(mock.loginOptions["ttl"], ShouldEqual, ttl+StartupGracePeriod)
+				So(mock.loginOptions["max_ttl"], ShouldEqual, ttl+StartupGracePeriod)
 			})
 
 			Convey("errors when Login fails", func() {
@@ -158,7 +158,7 @@ func Test_GetToken(t *testing.T) {
 }
 
 type mockTokenAuthHandler struct {
-	token             string
+	token string
 
 	LoginWasCalled    bool
 	ValidateWasCalled bool

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -28,7 +28,7 @@ func Capture(fn func()) string {
 
 func Test_NewDefaultVault(t *testing.T) {
 	Convey("NewDefaultVault()", t, func() {
-		Reset(func() { os.Unsetenv("EXECUTOR_VAULT_AWS_ROLE") })
+		Reset(func() { os.Unsetenv("EXECUTOR_AWS_ROLE") })
 
 		Convey("returns a properly configured Vault client", func() {
 			client := NewDefaultVault()
@@ -38,7 +38,7 @@ func Test_NewDefaultVault(t *testing.T) {
 		})
 
 		Convey("configures a service-specific token if required", func() {
-			os.Setenv("EXECUTOR_VAULT_AWS_ROLE", "some-role")
+			os.Setenv("EXECUTOR_AWS_ROLE", "some-role")
 
 			var client EnvVault
 

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -49,7 +49,7 @@ func Test_NewDefaultVault(t *testing.T) {
 			So(client, ShouldNotBeNil)
 			So(client.client, ShouldNotBeNil)
 
-			So(output, ShouldContainSubstring, "Attempting to get a parent token with TTL to match requested AWS Role")
+			So(output, ShouldContainSubstring, "Attempting to get a service-specific parent token with TTL to match requested AWS Role")
 		})
 	})
 }


### PR DESCRIPTION
This change will make sure that we have tokens for this instance of the executor that have a TTL at least as long as that requested for the AWS Role we are asking for. This will prevent issues where the TTL was longer than the parent and expiring early. Vault's API does not handle the response well when you ask for a TTL that exceeds that and it's not clear that will happen. This fixes the whole thing.

BREAKING CHANGE:
 * moves the configuration out of Docker labels and back into the main config since this behavior was not as useful as it appeared to be at first.