### PR TITLE
Parent token with TTL longer than AWS Role lease TTL

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Nitro/sidecar-executor/vault"
 	"github.com/Nitro/sidecar/service"
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/jinzhu/copier"
 	mesos "github.com/mesos/mesos-go/api/v1/lib"
 	"github.com/relistan/go-director"
 	log "github.com/sirupsen/logrus"
@@ -61,11 +62,15 @@ type sidecarExecutor struct {
 func newSidecarExecutor(client container.DockerClient, auth *docker.AuthConfiguration,
 	config Config) *sidecarExecutor {
 
+	// Mirror the settings we want in the sub-config, by matching keys
+	var vaultConfig vault.EnvVaultConfig
+	copier.Copy(&vaultConfig, &config)
+
 	return &sidecarExecutor{
 		client:          client,
 		fetcher:         &http.Client{Timeout: config.HttpTimeout},
 		dockerAuth:      auth,
-		vault:           vault.NewDefaultVault(),
+		vault:           vault.NewDefaultVault(&vaultConfig),
 		config:          config,
 		statusSleepTime: DefaultStatusSleepTime,
 	}

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/hashicorp/go-sockaddr v0.0.0-20180320115054-6d291a969b86
 	github.com/hashicorp/hcl v0.0.0-20180906183839-65a6292f0157
 	github.com/hashicorp/vault v1.0.1
+	github.com/jinzhu/copier v0.3.2 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1
 	github.com/mesos/mesos-go v0.0.10

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/hashicorp/hcl v0.0.0-20180906183839-65a6292f0157/go.mod h1:E5yfLk+7sw
 github.com/hashicorp/vault v1.0.1 h1:x3hcjkJLd5L4ehPhZcraokFO7dq8MJ3oKvQtrkIiIU8=
 github.com/hashicorp/vault v1.0.1/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/jinzhu/copier v0.3.2 h1:QdBOCbaouLDYaIPFfi1bKv5F5tPpeTwXe4sD0jqtz5w=
+github.com/jinzhu/copier v0.3.2/go.mod h1:24xnZezI2Yqac9J61UC6/dG/k76ttpq0DdJI3QmUvro=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/main.go
+++ b/main.go
@@ -52,8 +52,9 @@ type Config struct {
 	Debug                   bool          `envconfig:"DEBUG" default:"false"`
 
 	// AWS Role options
-	AWSRole    string        `envconfig:"AWS_ROLE"`
-	AWSRoleTTL time.Duration `envconfig:"AWS_ROLE_TTL"`
+	AWSRole       string        `envconfig:"AWS_ROLE" copier:"must"`
+	AWSRoleTTL    time.Duration `envconfig:"AWS_ROLE_TTL" copier:"must"`
+	AWSRoleMaxTTL time.Duration `envconfig:"AWS_ROLE_MAX_TTL" default:"744h" copier:"must"` // 31 days
 
 	// Mesos options
 	MesosMasterPort string `envconfig:"MESOS_MASTER_PORT" default:"5050"`
@@ -108,6 +109,7 @@ func logConfig(config Config) {
 	log.Infof(" * LogHostname:             %s", config.LogHostname)
 	log.Infof(" * AWSRole:                 %s", config.AWSRole)
 	log.Infof(" * AWSRoleTTL:              %s", config.AWSRoleTTL)
+	log.Infof(" * AWSRoleMaxTTL:           %s", config.AWSRoleMaxTTL)
 	log.Infof(" * Debug:                   %t", config.Debug)
 
 	log.Infof("Environment ---------------------------")

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -108,7 +108,7 @@ func getAWSRoleVaultToken(envVault *EnvVault) error {
 
 	log.Info("Attempting to get a service-specific parent token with TTL to match requested AWS Role")
 
-	if ttlStr := os.Getenv("EXECUTOR_AWS_TTL"); ttlStr != "" {
+	if ttlStr := os.Getenv("EXECUTOR_AWS_ROLE_TTL"); ttlStr != "" {
 		ttl, err = parseTokenTTL(ttlStr)
 		if err != nil {
 			return err
@@ -135,11 +135,13 @@ func getAWSRoleVaultToken(envVault *EnvVault) error {
 func parseTokenTTL(ttlStr string) (int, error) {
 	ttlTmp, err := time.ParseDuration(ttlStr)
 	if ttlTmp < 1 || err != nil {
-		return -1, fmt.Errorf("Invalid TTL passed in Docker label vaul.AWSRoleTTL. Could not parse: '%s'", ttlStr)
+		return -1, fmt.Errorf("Invalid TTL passed in AWSRoleTTL . Could not parse: '%s'", ttlStr)
 	}
 
-	// Seconds() returns a float64. We want the seconds, downgraded to an int
-	ttl := int(ttlTmp.Seconds())
+	// We want the seconds in the duraction, downgraded to an int.
+	ttl := int(ttlTmp / time.Second)
+
+	log.Warnf("KMDEBUG: %s, %#v, %d", ttlStr, ttlTmp, ttl)
 
 	return ttl, nil
 }

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -141,8 +141,6 @@ func parseTokenTTL(ttlStr string) (int, error) {
 	// We want the seconds in the duraction, downgraded to an int.
 	ttl := int(ttlTmp / time.Second)
 
-	log.Warnf("KMDEBUG: %s, %#v, %d", ttlStr, ttlTmp, ttl)
-
 	return ttl, nil
 }
 

--- a/vault/vault_auth_test.go
+++ b/vault/vault_auth_test.go
@@ -55,7 +55,6 @@ func Test_GetTTL(t *testing.T) {
 func Test_GetToken(t *testing.T) {
 	Convey("GetToken()", t, func() {
 		mock := &mockTokenAuthHandler{}
-		ttl := GetTTL()
 
 		Convey("when VAULT_TOKEN_FILE is NOT set", func() {
 			os.Unsetenv("VAULT_TOKEN_FILE")
@@ -77,8 +76,6 @@ func Test_GetToken(t *testing.T) {
 				So(mock.ValidateWasCalled, ShouldBeFalse)
 				So(mock.token, ShouldEqual, "from_login")
 				So(mock.loginOptions["password"], ShouldEqual, "guinevere")
-				So(mock.loginOptions["ttl"], ShouldEqual, ttl+StartupGracePeriod)
-				So(mock.loginOptions["max_ttl"], ShouldEqual, ttl+StartupGracePeriod)
 			})
 
 			Convey("errors when Login fails", func() {
@@ -189,6 +186,10 @@ func (m *mockTokenAuthHandler) Login(username string, password string,
 	}
 
 	return m.token, nil
+}
+
+func (m *mockTokenAuthHandler) Renew(token string, ttl int) error {
+	return nil
 }
 
 func (m *mockTokenAuthHandler) SetToken(token string) {


### PR DESCRIPTION
It turns out that to do leases they way we were doing them, you cannot use a shared token with a TTL as short as we would like to. So this PR adds the ability for the executor to get its own Vault token specific to this particular executor instance and service, with a TTL that is longer than the TTL for the requested AWS Role. This now seems to do what we need. There are greace periods built in around the TTLs to make sure we can revoke them and that the parent really does last longer than the lease TTL. Unfortunately the Vault API is kinda nasty and the only way to get a requested TTL is to get the token and then renew it with a new TTL. This is now what we do.

*Note* The default MAX TTL for tokens needs to be longer than the TTL you ask for. Otherwise Vault will give you a shorter life token than requested.

